### PR TITLE
Wired Xbox controller connection

### DIFF
--- a/Firmware/RP2040/src/Board/Config.h
+++ b/Firmware/RP2040/src/Board/Config.h
@@ -17,13 +17,30 @@
     #define MAX_GAMEPADS 1
 #endif
 
-#if defined(CONFIG_OGXM_BOARD_PI_PICO) || defined(CONFIG_OGXM_BOARD_PI_PICO2)
+#if defined(CONFIG_OGXM_BOARD_PI_PICO)
     #define OGXM_BOARD          PI_PICO
     #define PIO_USB_DP_PIN      0 // DM = 1
     #define LED_INDICATOR_PIN   25
 
-#elif defined(CONFIG_OGXM_BOARD_PI_PICOW) || defined(CONFIG_OGXM_BOARD_PI_PICO2W)
+#elif defined(CONFIG_OGXM_BOARD_PI_PICO2)
+    #define OGXM_BOARD          PI_PICO
+    // Reserve GP0/GP1 for UART on Pico 2 by default.
+    #ifndef OGXM_PIO_USB_DP_PIN
+        #define OGXM_PIO_USB_DP_PIN 2
+    #endif
+    #define PIO_USB_DP_PIN      OGXM_PIO_USB_DP_PIN // DM = DP + 1
+    #define LED_INDICATOR_PIN   25
+
+#elif defined(CONFIG_OGXM_BOARD_PI_PICOW)
     #define OGXM_BOARD          PI_PICOW
+
+#elif defined(CONFIG_OGXM_BOARD_PI_PICO2W)
+    #define OGXM_BOARD          PI_PICOW
+    // If USB host is enabled for Pico 2 W, keep GP0/GP1 free for UART.
+    #ifndef OGXM_PIO_USB_DP_PIN
+        #define OGXM_PIO_USB_DP_PIN 2
+    #endif
+    #define PIO_USB_DP_PIN      OGXM_PIO_USB_DP_PIN // DM = DP + 1
 
 #elif defined(CONFIG_OGXM_BOARD_RP2040_ZERO)
     #define OGXM_BOARD          RP2040_ZERO

--- a/hardware/README.md
+++ b/hardware/README.md
@@ -5,6 +5,18 @@
 The Pico 2 will likely require 4.7k resistors between the USB data lines and ground to work correctly.
 ![OGX-Mini](../images/DiagramPico2.png)
 
+## Pico 2 W USB-A host pinout (UART-safe)
+To keep UART on GP0/GP1 available, wire the USB-A female host port to:
+- D+ -> GP2
+- D- -> GP3
+- GND -> GND
+- VBUS -> VSYS (prototype wiring) or a dedicated 5V host switch (recommended)
+
+Recommended signal conditioning:
+- 4.7k pull-down from D+ to GND
+- 4.7k pull-down from D- to GND
+- Optional: 27 ohm series resistor on D+ and D-
+
 # Pi Pico + ESP32
 This is the minumum amount of connections you'll want for this to work and the diagram assumes you're powering the Pico and ESP32 each separately via USB (do not connect power between the 2 boards if so). A more complex configuration is possible, making the Pi Pico able to program the ESP32, but I'll update the repo with that diagram later.
 ![OGX-Mini](../images/DiagramPicoESP32.png)


### PR DESCRIPTION
Remap Pico 2/2W USB host pins and update hardware docs to avoid conflict with UART on GP0/GP1.

This change moves the default PIO USB D+/D- pins for Pico 2 and Pico 2 W to GP2/GP3, allowing GP0/GP1 to remain available for UART functionality as observed in `main.cpp`. The hardware README is updated with the new, UART-safe wiring instructions for adding a USB-A host port.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-ec48b430-cd06-4efd-ab88-ac5dd0f2406f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ec48b430-cd06-4efd-ab88-ac5dd0f2406f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

